### PR TITLE
Refator page param

### DIFF
--- a/lib/pagy_mongoid_cursor/pagy/cursor.rb
+++ b/lib/pagy_mongoid_cursor/pagy/cursor.rb
@@ -1,17 +1,25 @@
 class Pagy
   class Cursor < Pagy
+    attr_reader :before, :after
 
     def initialize(vars)
       normalize_vars(vars)
       setup_items_var
       setup_params_var
-      @page = vars[:page]
+
+      direction, id = vars[:page].split(':') if vars[:page]
+
+      if direction == 'before'
+        @before = id
+      elsif direction == 'after'
+        @after = id
+      end
     end
 
-    def finalize(prev_id, next_id, last_id)
-      @prev = prev_id
-      @next = next_id
-      @last = last_id
+    def finalize(before_id, after_id, last_id)
+      @prev = "before:#{before_id}" if before_id
+      @next = "after:#{after_id}" if after_id
+      @last = "after:#{last_id}" if last_id
       self
     end
 


### PR DESCRIPTION
Changed it so the page param is a string in the format of `before:[id]` or `after:[id]` so we can eliminate an extra database call to determine the previous page
